### PR TITLE
Update Academic_Applied variable based on Membership_Dues

### DIFF
--- a/R/make_final_data.R
+++ b/R/make_final_data.R
@@ -14,6 +14,13 @@ make_final_data <- function(demo, dues, staff) {
     left_join(x = dues,
               y = demo,
               by = "SID")
+  
+  # update Academic_Applied based on Membership_Dues
+  df <- 
+    mutate(.data$Academic_Applied = case_when(
+                                      .data$Membership_Dues == "Student Affiliate" ~ "Student", 
+                                      TRUE ~ .data$Academic_Applied))
+                  
 
   df <- step_sid(df,
                  staff = staff)

--- a/R/step_academicapplied.R
+++ b/R/step_academicapplied.R
@@ -15,8 +15,7 @@ step_academicapplied <- function(df) {
           .data$`Academic Sector (Primary)` != "" ~ 'Academic',
           .data$`Government Sector (Primary)` != "" ~ 'Applied',
           .data$`Private Sector (Primary)` != "" ~ 'Applied',
-          .data$`Other Sector (Primary)` == "Other" ~ 'Applied',
-          TRUE ~ "Student" # Added per request, assumption NA = Student.
+          .data$`Other Sector (Primary)` == "Other" ~ 'Applied'
         )
     ) %>%
     mutate(


### PR DESCRIPTION
While working through the 2022 SIOP MAS EB Trends report (using the latest cleaned data), Jackie noted a potential issue with the `Academic_Applied` variable incorrectly categorizing cases into "Student". Specifically, based on 475b21bead953b732f9c46fb8e1dba9f19cf20a0, `step_academicapplied` seems to categorize all cases missing any primary work sector data as "Student", which miscategorizes ~970 cases in the 2022 dataset. 

As such, these edits are meant to update the `Academic_Applied` variable based on `Membership_Dues` during the final `make_final_data` step to cleanly categorize student members. This way, not all cases with missing data for primary work sector will be categorized as `Academic_Applied = "Student"`.